### PR TITLE
Hotfix slug-title conversion with underscore for dash

### DIFF
--- a/src/lib/data/helpers.ts
+++ b/src/lib/data/helpers.ts
@@ -2,13 +2,14 @@ import { productQueryString, QUERIES } from '../data/graphql/queries';
 import { QueryFilters } from '../types/types';
 
 export function getSlugFromTitle(title: string): string {
-  const slug = title.toLowerCase().replace(/\s+/g, '--');
-  return encodeURIComponent(slug);
+  return encodeURIComponent(title.toLowerCase())
+    .replace(/-/g, '_')
+    .replace(/%20/g, '-');
 }
 
 export function getTitleFromSlug(slug: string): string {
-  const title = decodeURIComponent(slug);
-  return title.replace(/--/g, ' ');
+  const title = slug.replace(/-/g, '%20').replace(/_/g, '-');
+  return decodeURIComponent(title);
 }
 
 // These query builders are used when we need to mimic the behavior that "where:" usually enables


### PR DESCRIPTION
### What changed

- When product titles are converted to slugs, dashes (`-`) are now converted to underscores (`_`), so that patterns such as `Tee - White` can be converted back to titles safely.
    - For SEO, dashes are treated as whitespace, and underscores as word "joiners", which is why we don't just replace spaces with something else and leave dashes as they are.

Closes #120 