### PR TITLE
Enh/card-grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-navigation-menu": "^1.2.14",
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -1643,6 +1644,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -2283,6 +2307,7 @@
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2293,6 +2318,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2343,6 +2369,7 @@
       "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.42.0",
         "@typescript-eslint/types": "8.42.0",
@@ -2860,6 +2887,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3494,7 +3522,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/culori": {
       "version": "4.0.2",
@@ -3684,7 +3713,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -3938,6 +3968,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4027,6 +4058,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4128,6 +4160,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6139,6 +6172,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
       "integrity": "sha512-H8Otr7abj1glFhbGnvUt3gz++0AF1+QoCXEBmd/6aKbfdFwrn0LpA836Ed5+00va/7HQSDD+mOoVhn3tNy3e/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.2",
         "@swc/helpers": "0.5.15",
@@ -6548,6 +6582,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6619,6 +6654,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6628,6 +6664,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7597,6 +7634,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7756,6 +7794,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.14",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { Separator } from '@/components/ui/separator';
 
 export default function Home() {
   return (
-    <main className="content-grid full-width space-y-8">
+    <main className="content-grid full-width">
       <Hero />
       <FeaturedProducts />
       <Separator />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,15 @@
 import FeaturedProducts from '@/components/root-page/featured-products';
 import Hero from '@/components/root-page/hero';
+import { NewProducts } from '@/components/root-page/new-products';
+import { Separator } from '@/components/ui/separator';
 
-export default async function Home() {
+export default function Home() {
   return (
-    <main className="content-grid full-width">
+    <main className="content-grid full-width space-y-8">
       <Hero />
       <FeaturedProducts />
+      <Separator />
+      <NewProducts />
     </main>
   );
 }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,4 +1,4 @@
-import ProductCard from '@/components/products/product-card';
+import { ProductCard } from '@/components/products/product-card';
 import ProductFilters from '@/components/products/product-filters';
 import ProductPagination from '@/components/products/product-pagination';
 import {

--- a/src/components/loading/card-grid-skeleton.tsx
+++ b/src/components/loading/card-grid-skeleton.tsx
@@ -1,0 +1,16 @@
+import { CardGridLayout } from '../products/card-grid';
+import { ProductCardSkeleton } from './product-card-skeleton';
+
+export function CardGridSkeleton({ cards }: { cards: number }) {
+  const list = Array.from({ length: cards }, (_, i) => i + 1);
+
+  return (
+    <ul className={CardGridLayout}>
+      {list.map((i) => (
+        <li key={i}>
+          <ProductCardSkeleton />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/loading/multi-line-skeleton.tsx
+++ b/src/components/loading/multi-line-skeleton.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from '../ui/skeleton';
+
+interface MultiLineSkeletonProps {
+  lines: number;
+  lineHeight: number;
+  lineSpacing: number;
+}
+
+export function MultiLineSkeleton({
+  lines,
+  lineHeight = 16,
+  lineSpacing = 8,
+}: MultiLineSkeletonProps) {
+  const list = Array.from({ length: lines - 1 }, (_, i) => i + 1);
+  const lineStyle = {
+    height: `${lineHeight}px`,
+    marginTop: `${lineSpacing / 2}px`,
+    marginBottom: `${lineSpacing / 2}px`,
+  };
+
+  return (
+    <div className="grid">
+      {list.map((i) => (
+        <Skeleton key={i} className="w-full" style={lineStyle} />
+      ))}
+      <Skeleton className="w-1/3" style={lineStyle} />
+    </div>
+  );
+}

--- a/src/components/loading/product-card-skeleton.tsx
+++ b/src/components/loading/product-card-skeleton.tsx
@@ -1,0 +1,23 @@
+import { Card } from '../ui/card';
+import { Skeleton } from '../ui/skeleton';
+import { MultiLineSkeleton } from './multi-line-skeleton';
+
+export function ProductCardSkeleton() {
+  return (
+    <Card className="grid grid-rows-subgrid row-span-5 gap-3 w-[16rem] p-4">
+      {/* Title skeleton */}
+      <MultiLineSkeleton lines={2} lineHeight={18} lineSpacing={10} />
+      {/* Image carousel skeleton */}
+      <Skeleton className="aspect-square w-full rounded-md order-first" />
+      {/* Description skeleton */}
+      <MultiLineSkeleton lines={3} lineHeight={14} lineSpacing={6} />
+      {/* Category/price skeleton */}
+      <div className="flex justify-between mt-1">
+        <Skeleton className="h-[28] w-[56] rounded-full" />
+        <Skeleton className="h-[28] w-[35] rounded-full" />
+      </div>
+      {/* AddToCart button skeleton */}
+      <Skeleton className="h-[36] w-full" />
+    </Card>
+  );
+}

--- a/src/components/products/add-to-cart-button.tsx
+++ b/src/components/products/add-to-cart-button.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useCart } from '@/lib/hooks/use-cart';
+import { Button } from '../ui/button';
+
+export function AddToCartButton({ className }: { className?: string }) {
+  const { addToCart, isPending, optimisticCount } = useCart();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    addToCart();
+  };
+
+  return (
+    <Button className={className} onClick={handleClick} disabled={isPending}>
+      {isPending ? 'Adding...' : 'Add to cart'}
+      {optimisticCount && (
+        <span className="ml-2 text-xs bg-white/20 px-1 rounded">
+          {optimisticCount}
+        </span>
+      )}
+    </Button>
+  );
+}

--- a/src/components/products/card-grid.tsx
+++ b/src/components/products/card-grid.tsx
@@ -1,0 +1,44 @@
+import { routes } from '@/lib/constants/routes';
+import { getSlugFromTitle } from '@/lib/data/helpers';
+import { Product } from '@/lib/types/product';
+import Link from 'next/link';
+import { ProductCard } from './product-card';
+
+export const CardGridLayout =
+  'grid grid-cols-[repeat(auto-fit,16rem)] gap-6 justify-center';
+
+export async function CardGrid({
+  productsPromise,
+}: {
+  productsPromise: Promise<Product[]>;
+}) {
+  const products = await productsPromise;
+
+  if (products.length === 0) {
+    return (
+      <p className="text-center text-muted-foreground italic">
+        No products found
+      </p>
+    );
+  }
+
+  return (
+    <ul className={CardGridLayout}>
+      {products.map((p, i) => {
+        const slug = getSlugFromTitle(p.title);
+
+        return (
+          <li key={i} className="contents">
+            <Link
+              href={`${routes.products.href}/${slug}`}
+              scroll={false}
+              className="contents"
+            >
+              <ProductCard product={p} />
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/products/product-card.tsx
+++ b/src/components/products/product-card.tsx
@@ -1,60 +1,25 @@
-'use client';
-
-import ProductImageCarousel from '@/components/products/product-image-carousel';
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { useCart } from '@/lib/hooks/use-cart';
 import { Product } from '@/lib/types/product';
+import { Card, CardDescription } from '../ui/card';
+import { AddToCartButton } from './add-to-cart-button';
+import ProductImageCarousel from './product-image-carousel';
 
-interface ProductCardProps {
-  product: Product;
-}
-
-export default function ProductCard({ product }: ProductCardProps) {
-  const { addToCart, isPending, optimisticCount } = useCart();
-
+export function ProductCard({ product }: { product: Product }) {
   return (
-    <Card className="w-full max-w-sm hover:shadow-lg transition-shadow duration-300 flex flex-col h-full">
-      <CardHeader className="p-4">
-        <div className="aspect-square relative overflow-hidden rounded-md">
-          <ProductImageCarousel images={product.images} title={product.title} />
-        </div>
-      </CardHeader>
-      <CardContent className="p-4 pt-0 flex-1">
-        <CardTitle className="line-clamp-2 text-lg mb-2">
-          {product.title}
-        </CardTitle>
-        <CardDescription className="line-clamp-3">
-          {product.description}
-        </CardDescription>
-      </CardContent>
-
-      <CardFooter className="p-4 pt-0 mt-auto flex-col gap-3">
-        <div className="flex items-center justify-between w-full">
-          <span className="text-2xl font-bold text-primary">
-            ${product.price}
-          </span>
-          <span className="text-xs bg-secondary text-secondary-foreground px-2 py-1 rounded-full">
-            {product.category.name}
-          </span>
-        </div>
-
-        <Button className="w-full" onClick={addToCart} disabled={isPending}>
-          {isPending ? 'Adding...' : 'Add to Cart'}
-          {optimisticCount && (
-            <span className="ml-2 text-xs bg-white/20 px-1 rounded">
-              {optimisticCount}
-            </span>
-          )}
-        </Button>
-      </CardFooter>
+    <Card className="grid grid-rows-subgrid row-span-5 gap-3 hover:shadow-xl transition-shadow duration-300 p-4">
+      <h3 className="line-clamp-2 text-lg font-semibold">{product.title}</h3>
+      <div className="aspect-square relative overflow-hidden rounded-md order-first">
+        <ProductImageCarousel images={product.images} title={product.title} />
+      </div>
+      <CardDescription className="line-clamp-3">
+        {product.description}
+      </CardDescription>
+      <div className="flex items-center justify-between mt-1">
+        <span className="text-xs bg-secondary text-secondary-foreground rounded-full px-2 py-1">
+          {product.category.name}
+        </span>
+        <span className="text-xl font-bold">${product.price}</span>
+      </div>
+      <AddToCartButton className="w-full" />
     </Card>
   );
 }

--- a/src/components/products/product-card.tsx
+++ b/src/components/products/product-card.tsx
@@ -6,7 +6,7 @@ import ProductImageCarousel from './product-image-carousel';
 export function ProductCard({ product }: { product: Product }) {
   return (
     <Card className="grid grid-rows-subgrid row-span-5 gap-3 hover:shadow-xl transition-shadow duration-300 p-4">
-      <h3 className="line-clamp-2 text-lg font-semibold">{product.title}</h3>
+      <h2 className="line-clamp-2 text-lg font-semibold">{product.title}</h2>
       <div className="aspect-square relative overflow-hidden rounded-md order-first">
         <ProductImageCarousel images={product.images} title={product.title} />
       </div>

--- a/src/components/root-page/featured-products.tsx
+++ b/src/components/root-page/featured-products.tsx
@@ -1,40 +1,28 @@
-import ProductCard from '@/components/products/product-card';
 import { routes } from '@/lib/constants/routes';
-import { getSlugFromTitle } from '@/lib/data/helpers';
-import { getProducts } from '@/lib/data/product-data-service';
+import { getProductsPaginated } from '@/lib/data/product-data-service';
+
 import Link from 'next/link';
+import { Suspense } from 'react';
+import { CardGrid, CardGridLayout } from '../products/card-grid';
 
-export default async function FeaturedProducts() {
-  const products = await getProducts();
-
-  if (!products || products.length === 0) {
-    return (
-      <div className="text-center py-8">
-        <p className="text-muted-foreground">No products found</p>
-      </div>
-    );
-  }
+export default function FeaturedProducts() {
+  const numProducts = 4;
 
   return (
-    <section className="full-width py-12 bg-gray-100">
-      <div className="container mx-auto">
-        <h2 className="text-3xl font-bold text-center mb-8">
-          Featured Products
-        </h2>
-        <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {products.slice(0, 20).map((product) => {
-            const slug = getSlugFromTitle(product.title);
-
-            return (
-              <li key={product.id}>
-                <Link href={`${routes.products.href}/${slug}`} scroll={false}>
-                  <ProductCard product={product} />
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+    <section className="content-grid full-width bg-gray-50 space-y-8 py-8">
+      <header className={CardGridLayout}>
+        <div className="col-span-full flex justify-between items-baseline text-green-800">
+          <h2 className="flex-1 text-3xl text-center md:text-left">
+            Featured Products
+          </h2>
+          <Link href={routes.products.href} className="text-xl hidden md:block">
+            view all
+          </Link>
+        </div>
+      </header>
+      <Suspense fallback={''}>
+        <CardGrid productsPromise={getProductsPaginated(numProducts, 0)} />
+      </Suspense>
     </section>
   );
 }

--- a/src/components/root-page/featured-products.tsx
+++ b/src/components/root-page/featured-products.tsx
@@ -3,13 +3,14 @@ import { getProductsPaginated } from '@/lib/data/product-data-service';
 
 import Link from 'next/link';
 import { Suspense } from 'react';
+import { CardGridSkeleton } from '../loading/card-grid-skeleton';
 import { CardGrid, CardGridLayout } from '../products/card-grid';
 
 export default function FeaturedProducts() {
   const numProducts = 4;
 
   return (
-    <section className="content-grid full-width bg-gray-50 space-y-8 py-8">
+    <section className="content-grid full-width bg-gray-50 space-y-8 py-16">
       <header className={CardGridLayout}>
         <div className="col-span-full flex justify-between items-baseline text-green-800">
           <h2 className="flex-1 text-3xl text-center md:text-left">
@@ -20,7 +21,7 @@ export default function FeaturedProducts() {
           </Link>
         </div>
       </header>
-      <Suspense fallback={''}>
+      <Suspense fallback={<CardGridSkeleton cards={numProducts} />}>
         <CardGrid productsPromise={getProductsPaginated(numProducts, 0)} />
       </Suspense>
     </section>

--- a/src/components/root-page/new-products.tsx
+++ b/src/components/root-page/new-products.tsx
@@ -1,5 +1,6 @@
 import { getProductsPaginated } from '@/lib/data/product-data-service';
 import { Suspense } from 'react';
+import { CardGridSkeleton } from '../loading/card-grid-skeleton';
 import { CardGrid, CardGridLayout } from '../products/card-grid';
 
 export function NewProducts() {
@@ -7,13 +8,13 @@ export function NewProducts() {
   const offset = 4;
 
   return (
-    <section className="content-grid full-width bg-gray-50 space-y-8 py-8">
+    <section className="content-grid full-width bg-gray-50 space-y-8 py-16">
       <header className={CardGridLayout}>
         <h2 className=" col-span-full text-green-800 text-3xl text-center md:text-left">
           New arrivals
         </h2>
       </header>
-      <Suspense fallback={''}>
+      <Suspense fallback={<CardGridSkeleton cards={numProducts} />}>
         <CardGrid productsPromise={getProductsPaginated(numProducts, offset)} />
       </Suspense>
     </section>

--- a/src/components/root-page/new-products.tsx
+++ b/src/components/root-page/new-products.tsx
@@ -1,0 +1,21 @@
+import { getProductsPaginated } from '@/lib/data/product-data-service';
+import { Suspense } from 'react';
+import { CardGrid, CardGridLayout } from '../products/card-grid';
+
+export function NewProducts() {
+  const numProducts = 4;
+  const offset = 4;
+
+  return (
+    <section className="content-grid full-width bg-gray-50 space-y-8 py-8">
+      <header className={CardGridLayout}>
+        <h2 className=" col-span-full text-green-800 text-3xl text-center md:text-left">
+          New arrivals
+        </h2>
+      </header>
+      <Suspense fallback={''}>
+        <CardGrid productsPromise={getProductsPaginated(numProducts, offset)} />
+      </Suspense>
+    </section>
+  );
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import * as React from 'react';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+
+import { cn } from '@/lib/utils';
+
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-accent animate-pulse rounded-md', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
### What changed

- Created reusable CardGrid component:
    - **Async:** takes a promise as props and awaits it, meaning can be wrapped with Suspense so page can load
    - sub-grid layout keeps content aligned
- Restructured ProductCard slightly for semantics and simplicity.
    - Extracted "AddToCart" button so the rest can remain a server component.
- Added loading skeleton for CardGrid & ProductCard:
    - when wrapping `CardGrid` in a Suspense boundary, can use CardGridSkeleton as a fallback and just specify the number of cards you need
- Used CardGrid & loading skeleton in HomePage 'Featured Products' and 'New Arrivals' section (screenshots below)

**Note:** I haven't added CardGrid to the products page yet, as the page needs quite a bit of refactoring

Closes #72 

_Home Page_
<img width="1720" height="1269" alt="image" src="https://github.com/user-attachments/assets/ce981254-4299-45de-8fff-904ce14d5236" />

_Loading skeleton (pulses)_
<img width="1720" height="1177" alt="image" src="https://github.com/user-attachments/assets/a965531c-0421-498d-a7ef-6b56713b3e6c" />